### PR TITLE
fix(aws): cleanup shutdown timing on AWS

### DIFF
--- a/src/gha_runner/__main__.py
+++ b/src/gha_runner/__main__.py
@@ -114,7 +114,6 @@ def stop_runner_instances(
     print("Waiting for instance to be removed...")
     try:
         cloud.wait_until_removed(instance_ids)
-        print("Instances removed!")
     except Exception as e:
         # Print to stdout
         print(f"Failed to remove instances check AWS console: {e}")
@@ -123,6 +122,8 @@ def stop_runner_instances(
             f"::error title=Failed to remove instances check AWS console::{e}"
         )
         exit(1)
+    else:
+        print("Instances removed!")
 
 
 def main():  # pragma: no cover

--- a/src/gha_runner/__main__.py
+++ b/src/gha_runner/__main__.py
@@ -112,8 +112,17 @@ def stop_runner_instances(
     print("Removing instances...")
     cloud.remove_instances(instance_ids)
     print("Waiting for instance to be removed...")
-    cloud.wait_until_removed(instance_ids)
-    print("Instances removed!")
+    try:
+        cloud.wait_until_removed(instance_ids)
+        print("Instances removed!")
+    except Exception as e:
+        # Print to stdout
+        print(f"Failed to remove instances check AWS console: {e}")
+        # Print to Annotations
+        print(
+            f"::error title=Failed to remove instances check AWS console::{e}"
+        )
+        exit(1)
 
 
 def main():  # pragma: no cover

--- a/src/gha_runner/clouddeployment.py
+++ b/src/gha_runner/clouddeployment.py
@@ -199,7 +199,6 @@ class AWS(CloudDeployment):
     def wait_until_removed(self, ids: list[str], **kwargs):
         ec2 = boto3.client("ec2", self.region_name)
         waiter = ec2.get_waiter("instance_terminated")
-        waiter_config = {"Delay": 15, "MaxAttempts": 80}
 
         if kwargs:
             waiter.wait(InstanceIds=ids, WaiterConfig=kwargs)

--- a/src/gha_runner/clouddeployment.py
+++ b/src/gha_runner/clouddeployment.py
@@ -199,11 +199,14 @@ class AWS(CloudDeployment):
     def wait_until_removed(self, ids: list[str], **kwargs):
         ec2 = boto3.client("ec2", self.region_name)
         waiter = ec2.get_waiter("instance_terminated")
-        waiter.wait(InstanceIds=ids)
+        waiter_config = {"Delay": 15, "MaxAttempts": 80}
+
         if kwargs:
             waiter.wait(InstanceIds=ids, WaiterConfig=kwargs)
         else:
-            waiter.wait(InstanceIds=ids)
+            # Use a longer WaiterConfig to allow for GPU to properly terminate
+            waiter_config = {"MaxAttempts": 80}
+            waiter.wait(InstanceIds=ids, WaiterConfig=waiter_config)
 
     def instance_running(self, id: str) -> bool:
         ec2 = boto3.client("ec2", self.region_name)

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -226,6 +226,14 @@ def test_wait_until_removed_dne(aws):
         aws.wait_until_removed(ids, **params)
 
 
+@pytest.mark.slow
+def test_wait_until_removed_dne_long(aws):
+    # This is a fake instance id
+    ids = ["i-xxxxxxxxxxxxxxxxx"]
+    with pytest.raises(WaiterError):
+        aws.wait_until_removed(ids)
+
+
 def test_build_user_data(aws):
     params = {
         "homedir": "/home/ec2-user",


### PR DESCRIPTION
Adds a `try-except` to removal of AWS instances and adds a longer `WaiterConfig` for the longer GPU shutdown times.