### PR TITLE
feat: Add GitHub timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For more information see the [self-hosted runner security docs](https://docs.git
 | aws_tags              | The AWS tags to use for your runner, formatted as a JSON list. See `README` for more details.                      | false              |         |
 | extra_gh_labels       | Any extra GitHub labels to tag your runners with. Passed as a comma-separated list with no spaces.                 | false              |         |
 | instance_count        | The number of instances to create, defaults to 1                                                                   | false              | 1       |
-| gh_timeout            | The amount of timeout for waiting for a runner to be online by GitHub.                                             | false              | 600     |
+| gh_timeout            | The amount of timeout for waiting for a runner to be online by GitHub.                                             | false              | 1200    |
 
 ### AWS `stop` Inputs
 | Input             | Description                                                                                                                                                         | Required for stop| Default | Note |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For more information see the [self-hosted runner security docs](https://docs.git
 | aws_tags              | The AWS tags to use for your runner, formatted as a JSON list. See `README` for more details.                      | false              |         |
 | extra_gh_labels       | Any extra GitHub labels to tag your runners with. Passed as a comma-separated list with no spaces.                 | false              |         |
 | instance_count        | The number of instances to create, defaults to 1                                                                   | false              | 1       |
+| gh_timeout            | The amount of timeout for waiting for a runner to be online by GitHub.                                             | false              | 600     |
 
 ### AWS `stop` Inputs
 | Input             | Description                                                                                                                                                         | Required for stop| Default | Note |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For more information see the [self-hosted runner security docs](https://docs.git
 | aws_tags              | The AWS tags to use for your runner, formatted as a JSON list. See `README` for more details.                      | false              |         |
 | extra_gh_labels       | Any extra GitHub labels to tag your runners with. Passed as a comma-separated list with no spaces.                 | false              |         |
 | instance_count        | The number of instances to create, defaults to 1                                                                   | false              | 1       |
-| gh_timeout            | The amount of timeout for waiting for a runner to be online by GitHub.                                             | false              | 1200    |
+| gh_timeout            | The timeout in seconds to wait for the runner to come online as seen by the GitHub API. Defaults to 1200 seconds.  | false              | 1200    |
 
 ### AWS `stop` Inputs
 | Input             | Description                                                                                                                                                         | Required for stop| Default | Note |

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: gha-runner
 description: A simple GitHub Action for creating self-hosted runners.
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 inputs:
   action:
     description: 'Whether to start or stop. Options: "start", "stop"'
@@ -37,9 +37,9 @@ inputs:
   instance_count:
     description: "The number of instances to create, defaults to 1"
     required: false
-    default: '1'
+    default: "1"
   instance_mapping:
-    description: 'A JSON object mapping instance ids to unique GitHub runner labels. Required to stop created instances.'
+    description: "A JSON object mapping instance ids to unique GitHub runner labels. Required to stop created instances."
     required: false
   provider:
     description: 'The cloud provider to use to provision a runner. Will not start if not set. Example: "aws"'
@@ -48,7 +48,7 @@ inputs:
     description: "The repo to run against. Will use the the current repo if not specified."
     required: false
   gh_timeout:
-    description: 'The amount of timeout for waiting for a runner to be online by GitHub.'
+    description: "The timeout in seconds to wait for the runner to come online as seen by the GitHub API. Defaults to 1200 seconds."
     required: false
 outputs:
   mapping:

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
   repo:
     description: "The repo to run against. Will use the the current repo if not specified."
     required: false
+  gh_timeout:
+    description: 'The amount of timeout for waiting for a runner to be online by GitHub.'
+    required: false
 outputs:
   mapping:
     description: "A JSON object mapping instance IDs to unique GitHub runner labels. This is used in conjection with the the `instance_mapping` input when stopping."

--- a/src/gha_runner/__main__.py
+++ b/src/gha_runner/__main__.py
@@ -148,7 +148,7 @@ def main():  # pragma: no cover
         raise Exception("Missing required input variable INPUT_PROVIDER")
     gh_timeout_var = os.environ.get("INPUT_GH_TIMEOUT")
     # Set the default timeout to 10 minutes
-    gh_timeout = 600
+    gh_timeout = 1200
     # If the user has set the timeout, we will use that instead
     if gh_timeout_var is not None:
         gh_timeout = int(gh_timeout_var)

--- a/src/gha_runner/__main__.py
+++ b/src/gha_runner/__main__.py
@@ -146,12 +146,9 @@ def main():  # pragma: no cover
     provider = os.environ.get("INPUT_PROVIDER")
     if provider is None:
         raise Exception("Missing required input variable INPUT_PROVIDER")
-    gh_timeout_var = os.environ.get("INPUT_GH_TIMEOUT")
-    # Set the default timeout to 10 minutes
+    # Set the default timeout to 20 minutes
+    gh_timeout = int(os.environ.get("INPUT_GH_TIMEOUT", 1200))
     gh_timeout = 1200
-    # If the user has set the timeout, we will use that instead
-    if gh_timeout_var is not None:
-        gh_timeout = int(gh_timeout_var)
 
     gha_params = {
         "token": os.environ["GH_PAT"],

--- a/src/gha_runner/__main__.py
+++ b/src/gha_runner/__main__.py
@@ -148,7 +148,6 @@ def main():  # pragma: no cover
         raise Exception("Missing required input variable INPUT_PROVIDER")
     # Set the default timeout to 20 minutes
     gh_timeout = int(os.environ.get("INPUT_GH_TIMEOUT", 1200))
-    gh_timeout = 1200
 
     gha_params = {
         "token": os.environ["GH_PAT"],

--- a/src/gha_runner/gh.py
+++ b/src/gha_runner/gh.py
@@ -201,7 +201,6 @@ class GitHubInstance:
             The time in seconds to wait between checks. Defaults to 15 seconds.
         timeout : int
             The maximum time in seconds to wait for the runner to be online.
-            Defaults to 300 seconds.
         """
         max = time.time() + timeout
         runner = self.get_runner(label)

--- a/src/gha_runner/gh.py
+++ b/src/gha_runner/gh.py
@@ -12,6 +12,7 @@ import string
 class TokenRetrievalError(Exception):
     """Exception raised when there is an error retrieving a token from GitHub."""
 
+
 class MissingRunnerLabel(Exception):
     """Exception raised when a runner does not exist in the repository."""
 
@@ -189,7 +190,7 @@ class GitHubInstance:
         ]
         return matched_runners if matched_runners else None
 
-    def wait_for_runner(self, label: str, wait: int = 15):
+    def wait_for_runner(self, label: str, timeout: int, wait: int = 15):
         """Wait for the runner with the given label to be online.
 
         Parameters
@@ -198,10 +199,15 @@ class GitHubInstance:
             The label of the runner to wait for.
         wait : int
             The time in seconds to wait between checks. Defaults to 15 seconds.
-
+        timeout : int
+            The maximum time in seconds to wait for the runner to be online.
+            Defaults to 300 seconds.
         """
+        max = time.time() + timeout
         runner = self.get_runner(label)
         while runner is None:
+            if time.time() > max:
+                raise RuntimeError(f"Timeout reached: Runner {label} not found")
             print(f"Runner {label} not found. Waiting...")
             runner = self.get_runner(label)
             time.sleep(wait)

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -2,7 +2,11 @@ import re
 import pytest
 from unittest.mock import patch, MagicMock, Mock
 
-from gha_runner.gh import TokenRetrievalError, GitHubInstance, MissingRunnerLabel
+from gha_runner.gh import (
+    TokenRetrievalError,
+    GitHubInstance,
+    MissingRunnerLabel,
+)
 from github.SelfHostedActionsRunner import SelfHostedActionsRunner
 
 
@@ -383,7 +387,7 @@ def mock_get_runner(monkeypatch):
 def test_wait_for_runner(github_release_mock, mock_get_runner, capsys):
     instance, _, _ = github_release_mock
     get_runner_mock, label, expected_calls = mock_get_runner
-    instance.wait_for_runner(label, wait=1)
+    instance.wait_for_runner(label, 10, wait=1)
     captured = capsys.readouterr()
     # Combine all expected calls into a single string
     combined = "".join(expected_calls)

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -396,3 +396,32 @@ def test_wait_for_runner(github_release_mock, mock_get_runner, capsys):
     assert captured.out == combined
     # Validate that the get_runner method was called the correct number of times
     assert get_runner_mock.call_count == len(expected_calls)
+
+@pytest.fixture
+def mock_get_runner_timeout(monkeypatch):
+    label = "runner-linux-x64"
+    side_effect = [None, None]
+    # Dynamically build out the expected calls based on the side_effect
+    expected_calls = [
+        f"Runner {label} not found. Waiting...\n ",
+    ]
+
+    get_runner_mock = MagicMock()
+    # Setup the side_effect for the get_runner_mock
+    get_runner_mock.side_effect = side_effect
+    monkeypatch.setattr(GitHubInstance, "get_runner", get_runner_mock)
+    return get_runner_mock, label, expected_calls
+
+def test_wait_for_runner_timeout(github_release_mock, mock_get_runner_timeout, capsys):
+    instance, _, _ = github_release_mock
+    get_runner_mock, label, expected_calls = mock_get_runner_timeout
+    with pytest.raises(RuntimeError, match=f"Timeout reached: Runner {label} not found"):
+        instance.wait_for_runner(label, timeout=1, wait=1)
+        captured = capsys.readouterr()
+        # Combine all expected calls into a single string
+        combined = "".join(expected_calls)
+
+        # Validate that the expected output matches the captured output
+        assert captured.out == combined
+        # Validate that the get_runner method was called the correct number of times
+        assert get_runner_mock.call_count == len(expected_calls)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -181,6 +181,7 @@ def test_start_runner_instances_smoke(
             gh=mock_gh,
             count=1,
             cloud_params={},
+            timeout=0,
         )
     except Exception as e:
         pytest.fail(f"Exception raised: {e}")


### PR DESCRIPTION
The purpose of this PR is to add the required changes to enable a configurable timeout on waiting for the runner to become registered with GitHub.
