### PR TITLE
ci: Only run non-docs changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,15 @@ name: CI
 
 on:
   push:
+    paths-ignore:
+      - "docs/**"
+      - "README.md"
     branches:
       - "main"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "README.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This ensures that we don't run CI on docs changes only. This should help to speed up contribution to documentation.
