### PR TITLE
ci: Ignore coverage on actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,14 @@ name: CI
 on:
   push:
     paths-ignore:
+      - ".github/**"
       - "docs/**"
       - "README.md"
     branches:
       - "main"
   pull_request:
     paths-ignore:
+      - ".github/**"
       - "docs/**"
       - "README.md"
   workflow_dispatch:


### PR DESCRIPTION
This pull request includes a minor update to the CI configuration file to improve the workflow efficiency by ignoring changes in `.github/`.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR6-R13): Updated the `paths-ignore` section to include the `.github/**` directory for both `push` and `pull_request` events.