### PR TITLE
refactor: Remove PyGitHub as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ test = [
     "pytest",
     "pytest-cov",
     "moto[ec2]",
+    "responses"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A GitHub Runner for deploying on cloud backends"
 authors = [{ name = "Ethan Holz", email = "ethan.holz@omsf.io" }]
 readme = "README.md"
 requires-python = ">= 3.10"
-dependencies = ["boto3", "PyGithub"]
+dependencies = ["boto3"]
 
 [project.optional-dependencies]
 test = [

--- a/src/gha_runner/gh.py
+++ b/src/gha_runner/gh.py
@@ -205,6 +205,19 @@ class GitHubInstance:
             raise RunnerListError(f"Error getting runners: {e}")
 
     def get_runner(self, label: str) -> SelfHostedRunner:
+        """Get a runner by a given label for a repository.
+
+        Returns
+        -------
+        SelfHostedRunner
+            The runner with the given label.
+
+        Raises
+        ------
+        MissingRunnerLabel
+            If the runner with the given label is not found.
+
+        """
         runners = self.get_runners()
         if runners is not None:
             for runner in runners:

--- a/src/gha_runner/gh.py
+++ b/src/gha_runner/gh.py
@@ -1,8 +1,8 @@
 """Module to manage GitHub repository actions through the GitHub API."""
 
-from github import Github, Auth
-from github.SelfHostedActionsRunner import SelfHostedActionsRunner
+from json import JSONDecodeError
 import urllib.parse
+from dataclasses import dataclass
 import requests
 import time
 import random
@@ -15,6 +15,18 @@ class TokenRetrievalError(Exception):
 
 class MissingRunnerLabel(Exception):
     """Exception raised when a runner does not exist in the repository."""
+
+
+class RunnerListError(Exception):
+    """Exception raised when there is an error getting the list of runners."""
+
+
+@dataclass
+class SelfHostedRunner:
+    id: int
+    name: str
+    os: str
+    labels: list[str]
 
 
 class GitHubInstance:
@@ -42,8 +54,6 @@ class GitHubInstance:
     def __init__(self, token: str, repo: str):
         self.token = token
         self.headers = self._headers({})
-        auth = Auth.Token(token)
-        self.github = Github(auth=auth)
         self.repo = repo
 
     def _headers(self, header_kwargs):
@@ -83,7 +93,10 @@ class GitHubInstance:
                 f"Error in API call for {endpoint_url}: " f"{resp.content}"
             )
         else:
-            return resp.json()
+            try:
+                return resp.json()
+            except JSONDecodeError:
+                return resp.content
 
     def create_runner_tokens(self, count: int) -> list[str]:
         """Generate registration tokens for GitHub Actions runners.
@@ -149,46 +162,55 @@ class GitHubInstance:
         """
         return self._do_request(requests.post, endpoint, **kwargs)
 
-    def get_runner(self, label: str) -> SelfHostedActionsRunner | None:
-        """Retrieve a runner by its label.
+    def get(self, endpoint, **kwargs):
+        """Make a GET request to the GitHub API.
 
         Parameters
         ----------
-        label : str
-            The label of the runner to retrieve.
-
-        Returns
-        -------
-        SelfHostedActionsRunner | None
-            The runner object if found, otherwise None.
-
+        endpoint : str
+            The endpoint to make the request to.
+        **kwargs : dict, optional
+            Additional keyword arguments to pass to the request.
+            See the requests.get documentation for more information.
         """
-        runners = self.github.get_repo(self.repo).get_self_hosted_runners()
-        matched_runners = [
-            runner
-            for runner in runners
-            if label in [l["name"] for l in runner.labels()]
-        ]
-        return matched_runners[0] if matched_runners else None
+        return self._do_request(requests.get, endpoint, **kwargs)
 
-    def get_runners(self, label: str) -> list[SelfHostedActionsRunner] | None:
-        """Get runners by their label.
+    def delete(self, endpoint, **kwargs):
+        """Make a DELETE request to the GitHub API.
+
         Parameters
         ----------
-        label : str
-            The label of the runners to retrieve.
-        Returns
-        -------
-        list[SelfHostedActionsRunner] | None
-            The list of runners if found, otherwise None.
+        endpoint : str
+            The endpoint to make the request to.
+        **kwargs : dict, optional
+            Additional keyword arguments to pass to the request.
+            See the requests.delete documentation for more information.
         """
-        runners = self.github.get_repo(self.repo).get_self_hosted_runners()
-        matched_runners = [
-            runner
-            for runner in runners
-            if label in [l["name"] for l in runner.labels()]
-        ]
-        return matched_runners if matched_runners else None
+        return self._do_request(requests.delete, endpoint, **kwargs)
+
+    def get_runners(self) -> list[SelfHostedRunner] | None:
+        runners = []
+        try:
+            res = self.get(f"repos/{self.repo}/actions/runners")
+            if type(res) is not dict:
+                raise RunnerListError(f"Error getting runners: {res}")
+            for runner in res["runners"]:
+                id = runner["id"]
+                name = runner["name"]
+                os = runner["os"]
+                labels = [label["name"] for label in runner["labels"]]
+                runners.append(SelfHostedRunner(id, name, os, labels))
+            return runners if len(runners) > 0 else None
+        except Exception as e:
+            raise RunnerListError(f"Error getting runners: {e}")
+
+    def get_runner(self, label: str) -> SelfHostedRunner:
+        runners = self.get_runners()
+        if runners is not None:
+            for runner in runners:
+                if label in runner.labels:
+                    return runner
+        raise MissingRunnerLabel(f"Runner {label} not found")
 
     def wait_for_runner(self, label: str, timeout: int, wait: int = 15):
         """Wait for the runner with the given label to be online.
@@ -214,52 +236,20 @@ class GitHubInstance:
 
     def remove_runner(self, label: str):
         """Remove a runner by a given label.
-
         Parameters
         ----------
         label : str
             The label of the runner to remove.
-
         Raises
         ------
         RuntimeError
             If there is an error removing the runner or the runner is not found.
-
         """
         runner = self.get_runner(label)
-        if runner is not None:
-            removed = self.github.get_repo(self.repo).remove_self_hosted_runner(
-                runner
-            )
-            if not removed:
-                raise RuntimeError(f"Error removing runner {label}")
-        else:
-            raise MissingRunnerLabel(f"Runner {label} not found")
-
-    def remove_runners(self, label: str):
-        """Remove runners by their label.
-
-        Parameters
-        ----------
-        label : str
-            The label of the runners to remove.
-
-        Raises
-        ------
-        RuntimeError
-            If there is an error removing the runners or the runners are not found.
-
-        """
-        runners = self.get_runners(label)
-        if runners is not None:
-            for runner in runners:
-                removed = self.github.get_repo(
-                    self.repo
-                ).remove_self_hosted_runner(runner)
-                if not removed:
-                    raise RuntimeError(f"Error removing runner {label}")
-        else:
-            raise MissingRunnerLabel(f"Runner {label} not found")
+        try:
+            self.delete(f"repos/{self.repo}/actions/runners/{runner.id}")
+        except Exception as e:
+            raise RuntimeError(f"Error removing runner {label}. Error: {e}")
 
     @staticmethod
     def generate_random_label() -> str:
@@ -276,6 +266,23 @@ class GitHubInstance:
         letters = string.ascii_lowercase + string.digits
         result_str = "".join(random.choice(letters) for i in range(8))
         return f"runner-{result_str}"
+
+    def _get_latest_release(self, repo: str) -> dict:
+        """Get the latest release for a repository.
+        Parameters
+        ----------
+        repo : str
+            The repository to get the latest release for.
+        Returns
+        -------
+        str
+            The tag name of the latest release.
+        """
+        try:
+            release = self.get(f"repos/{repo}/releases/latest")
+            return release
+        except Exception as e:
+            raise RuntimeError(f"Error getting latest release: {e}")
 
     def get_latest_runner_release(
         self, platform: str, architecture: str
@@ -314,11 +321,11 @@ class GitHubInstance:
                 f"Architecture '{architecture}' not supported for platform '{platform}'. "
                 f"Supported architectures are {supported_platforms[platform]}"
             )
-        release = self.github.get_repo(repo).get_latest_release()
-        assets = release.get_assets()
+        release = self._get_latest_release(repo)
+        assets = release["assets"]
         for asset in assets:
-            if platform in asset.name and architecture in asset.name:
-                return asset.browser_download_url
+            if platform in asset["name"] and architecture in asset["name"]:
+                return asset["browser_download_url"]
         raise RuntimeError(
             f"Runner release not found for platform {platform} and architecture {architecture}"
         )

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -114,7 +114,7 @@ def test_get_runners_no_json(github_instance):
         body="",
         status=200,
     )
-    with pytest.raises(RunnerListError, match="Error getting runners: *"):
+    with pytest.raises(RunnerListError, match="Did not receive mapping object: *"):
         github_instance.get_runners()
 
 

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -22,286 +22,296 @@ def mock_runner():
     )
 
 
-class TestGitHubInstance:
-    def test_init(self, github_instance):
-        assert github_instance.token == "fake-token"
-        assert github_instance.repo == "test/test"
-        assert github_instance.BASE_URL == "https://api.github.com"
+def test_init(github_instance):
+    assert github_instance.token == "fake-token"
+    assert github_instance.repo == "test/test"
+    assert github_instance.BASE_URL == "https://api.github.com"
 
-    def test_headers(self, github_instance):
-        headers = github_instance._headers({})
-        assert headers["Authorization"] == "Bearer fake-token"
-        assert headers["X-Github-Api-Version"] == "2022-11-28"
-        assert headers["Accept"] == "application/vnd.github+json"
 
-    @responses.activate
-    def test_create_runner_token(self, github_instance):
+def test_headers(github_instance):
+    headers = github_instance._headers({})
+    assert headers["Authorization"] == "Bearer fake-token"
+    assert headers["X-Github-Api-Version"] == "2022-11-28"
+    assert headers["Accept"] == "application/vnd.github+json"
+
+
+@responses.activate
+def test_create_runner_token(github_instance):
+    responses.add(
+        responses.POST,
+        "https://api.github.com/repos/test/test/actions/runners/registration-token",
+        json={"token": "test-token"},
+        status=200,
+    )
+    token = github_instance.create_runner_token()
+    assert token == "test-token"
+
+
+@responses.activate
+def test_create_runner_token_error(github_instance):
+    responses.add(
+        responses.POST,
+        "https://api.github.com/repos/test/test/actions/runners/registration-token",
+        status=400,
+    )
+    with pytest.raises(TokenRetrievalError):
+        github_instance.create_runner_token()
+
+
+@responses.activate
+def test_create_runner_tokens(github_instance):
+    tokens = ["test-token-1", "test-token-2", "test-token-3"]
+    for token in tokens:
         responses.add(
             responses.POST,
             "https://api.github.com/repos/test/test/actions/runners/registration-token",
-            json={"token": "test-token"},
+            json={"token": token},
             status=200,
         )
-        token = github_instance.create_runner_token()
-        assert token == "test-token"
+    assert github_instance.create_runner_tokens(3) == tokens
 
-    @responses.activate
-    def test_create_runner_token_error(self, github_instance):
+
+@responses.activate
+def test_get_runners(github_instance):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/test/test/actions/runners",
+        json={
+            "runners": [
+                {
+                    "id": 1,
+                    "name": "test-runner",
+                    "os": "linux",
+                    "labels": [{"name": "test-label"}],
+                }
+            ]
+        },
+        status=200,
+    )
+    runners = github_instance.get_runners()
+    assert len(runners) == 1
+    assert runners[0].id == 1
+    assert runners[0].name == "test-runner"
+    assert runners[0].labels == ["test-label"]
+
+
+@responses.activate
+def test_get_runners_empty(github_instance):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/test/test/actions/runners",
+        json={"runners": []},
+        status=200,
+    )
+    assert github_instance.get_runners() is None
+
+
+@responses.activate
+def test_get_runners_no_json(github_instance):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/test/test/actions/runners",
+        body="",
+        status=200,
+    )
+    with pytest.raises(RunnerListError, match="Error getting runners: *"):
+        github_instance.get_runners()
+
+
+@responses.activate
+def test_get_runners_error(github_instance):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/test/test/actions/runners",
+        status=500,
+    )
+    with pytest.raises(RunnerListError, match="Error getting runners: *"):
+        github_instance.get_runners()
+
+
+def test_get_runner_by_label(github_instance, mock_runner):
+    with patch.object(
+        github_instance, "get_runners", return_value=[mock_runner]
+    ):
+        runner = github_instance.get_runner("test-label")
+        assert runner.id == 1
+        assert runner.name == "test-runner"
+
+
+def test_get_runner_missing_label(github_instance):
+    with patch.object(github_instance, "get_runners", return_value=[]):
+        with pytest.raises(MissingRunnerLabel):
+            github_instance.get_runner("nonexistent-label")
+
+
+@responses.activate
+def test_remove_runner(github_instance, mock_runner):
+    with patch.object(github_instance, "get_runner", return_value=mock_runner):
         responses.add(
-            responses.POST,
-            "https://api.github.com/repos/test/test/actions/runners/registration-token",
-            status=400,
+            responses.DELETE,
+            f"https://api.github.com/repos/test/test/actions/runners/{mock_runner.id}",
+            status=204,
         )
-        with pytest.raises(TokenRetrievalError):
-            github_instance.create_runner_token()
+        github_instance.remove_runner("test-label")
 
-    @responses.activate
-    def test_create_runner_tokens(self, github_instance):
-        tokens = ["test-token-1", "test-token-2", "test-token-3"]
-        for token in tokens:
-            responses.add(
-                responses.POST,
-                "https://api.github.com/repos/test/test/actions/runners/registration-token",
-                json={"token": token},
-                status=200,
-            )
-        assert github_instance.create_runner_tokens(3) == tokens
 
-    @responses.activate
-    def test_get_runners(self, github_instance):
+@responses.activate
+def test_remove_runner_error(github_instance, mock_runner):
+    with patch.object(github_instance, "get_runner", return_value=mock_runner):
         responses.add(
-            responses.GET,
-            "https://api.github.com/repos/test/test/actions/runners",
-            json={
-                "runners": [
-                    {
-                        "id": 1,
-                        "name": "test-runner",
-                        "os": "linux",
-                        "labels": [{"name": "test-label"}],
-                    }
-                ]
-            },
-            status=200,
-        )
-        runners = github_instance.get_runners()
-        assert len(runners) == 1
-        assert runners[0].id == 1
-        assert runners[0].name == "test-runner"
-        assert runners[0].labels == ["test-label"]
-
-    @responses.activate
-    def test_get_runners_empty(self, github_instance):
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/test/test/actions/runners",
-            json={"runners": []},
-            status=200,
-        )
-        assert github_instance.get_runners() is None
-
-    @responses.activate
-    def test_get_runners_no_json(self, github_instance):
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/test/test/actions/runners",
-            body="",
-            status=200,
-        )
-        with pytest.raises(RunnerListError, match="Error getting runners: *"):
-            github_instance.get_runners()
-
-    @responses.activate
-    def test_get_runners_error(self, github_instance):
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/test/test/actions/runners",
+            responses.DELETE,
+            f"https://api.github.com/repos/test/test/actions/runners/{mock_runner.id}",
             status=500,
         )
-        with pytest.raises(RunnerListError, match="Error getting runners: *"):
-            github_instance.get_runners()
-
-    def test_get_runner_by_label(self, github_instance, mock_runner):
-        with patch.object(
-            github_instance, "get_runners", return_value=[mock_runner]
-        ):
-            runner = github_instance.get_runner("test-label")
-            assert runner.id == 1
-            assert runner.name == "test-runner"
-
-    def test_get_runner_missing_label(self, github_instance):
-        with patch.object(github_instance, "get_runners", return_value=[]):
-            with pytest.raises(MissingRunnerLabel):
-                github_instance.get_runner("nonexistent-label")
-
-    @responses.activate
-    def test_remove_runner(self, github_instance, mock_runner):
-        with patch.object(
-            github_instance, "get_runner", return_value=mock_runner
-        ):
-            responses.add(
-                responses.DELETE,
-                f"https://api.github.com/repos/test/test/actions/runners/{mock_runner.id}",
-                status=204,
-            )
+        with pytest.raises(RuntimeError):
             github_instance.remove_runner("test-label")
 
-    @responses.activate
-    def test_remove_runner_error(self, github_instance, mock_runner):
-        with patch.object(
-            github_instance, "get_runner", return_value=mock_runner
-        ):
-            responses.add(
-                responses.DELETE,
-                f"https://api.github.com/repos/test/test/actions/runners/{mock_runner.id}",
-                status=500,
-            )
-            with pytest.raises(RuntimeError):
-                github_instance.remove_runner("test-label")
 
-    def test_generate_random_label(self):
-        label = GitHubInstance.generate_random_label()
-        assert label.startswith("runner-")
-        assert len(label) == 15  # "runner-" + 8 random chars
+def test_generate_random_label():
+    label = GitHubInstance.generate_random_label()
+    assert label.startswith("runner-")
+    assert len(label) == 15  # "runner-" + 8 random chars
 
-    @responses.activate
-    def test_get_latest_runner_release(self, github_instance):
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/actions/runner/releases/latest",
-            json={
-                "assets": [
-                    {
-                        "name": "actions-runner-linux-x64-2.0.0.tar.gz",
-                        "browser_download_url": "https://example.com/runner.tar.gz",
-                    }
-                ]
-            },
-            status=200,
-        )
-        url = github_instance.get_latest_runner_release("linux", "x64")
-        assert url == "https://example.com/runner.tar.gz"
 
-    def test_get_latest_runner_release_invalid_platform(self, github_instance):
-        with pytest.raises(ValueError):
-            github_instance.get_latest_runner_release("invalid", "x64")
-
-    def test_get_latest_runner_release_invalid_arch(self, github_instance):
-        with pytest.raises(ValueError):
-            github_instance.get_latest_runner_release("linux", "invalid")
-
-    @patch("time.sleep")  # Prevent actual sleeping in tests
-    def test_wait_for_runner_success(
-        self, mock_sleep, github_instance, mock_runner
-    ):
-        with patch.object(
-            github_instance, "get_runner", side_effect=[None, mock_runner]
-        ):
-            github_instance.wait_for_runner("test-label", timeout=30)
-            assert mock_sleep.call_count == 1
-
-    @patch("time.sleep")
-    @patch("time.time", side_effect=[0, 31])
-    def test_wait_for_runner_timeout(
-        self, mock_time, mock_sleep, github_instance
-    ):
-        with patch.object(github_instance, "get_runner", return_value=None):
-            with pytest.raises(RuntimeError):
-                github_instance.wait_for_runner("test-label", timeout=30)
-
-    @responses.activate
-    def test_get_latest_release(self, github_instance):
-        json = {
-            "url": "https://api.github.com/repos/octocat/Hello-World/releases/1",
-            "html_url": "https://github.com/octocat/Hello-World/releases/v1.0.0",
-            "assets_url": "https://api.github.com/repos/octocat/Hello-World/releases/1/assets",
-            "upload_url": "https://uploads.github.com/repos/octocat/Hello-World/releases/1/assets{?name,label}",
-            "tarball_url": "https://api.github.com/repos/octocat/Hello-World/tarball/v1.0.0",
-            "zipball_url": "https://api.github.com/repos/octocat/Hello-World/zipball/v1.0.0",
-            "discussion_url": "https://github.com/octocat/Hello-World/discussions/90",
-            "id": 1,
+@responses.activate
+def test_get_latest_runner_release(github_instance):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/actions/runner/releases/latest",
+        json={
             "assets": [
                 {
-                    "url": "https://api.github.com/repos/octocat/Hello-World/releases/assets/1",
-                    "browser_download_url": "https://github.com/octocat/Hello-World/releases/download/v1.0.0/example.zip",
-                    "id": 1,
-                    "node_id": "MDEyOlJlbGVhc2VBc3NldDE=",
-                    "name": "example.zip",
-                    "label": "short description",
-                    "state": "uploaded",
-                    "content_type": "application/zip",
-                    "size": 1024,
-                    "download_count": 42,
-                    "created_at": "2013-02-27T19:35:32Z",
-                    "updated_at": "2013-02-27T19:35:32Z",
-                    "uploader": {
-                        "login": "octocat",
-                        "id": 1,
-                        "node_id": "MDQ6VXNlcjE=",
-                        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
-                        "gravatar_id": "",
-                        "url": "https://api.github.com/users/octocat",
-                        "html_url": "https://github.com/octocat",
-                        "followers_url": "https://api.github.com/users/octocat/followers",
-                        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
-                        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
-                        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
-                        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
-                        "organizations_url": "https://api.github.com/users/octocat/orgs",
-                        "repos_url": "https://api.github.com/users/octocat/repos",
-                        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
-                        "received_events_url": "https://api.github.com/users/octocat/received_events",
-                        "type": "User",
-                        "site_admin": False,
-                    },
+                    "name": "actions-runner-linux-x64-2.0.0.tar.gz",
+                    "browser_download_url": "https://example.com/runner.tar.gz",
                 }
-            ],
-        }
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/actions/runner/releases/latest",
-            status=200,
-            json=json,
-        )
-        body = github_instance._get_latest_release(repo="actions/runner")
-        assert body == json
+            ]
+        },
+        status=200,
+    )
+    url = github_instance.get_latest_runner_release("linux", "x64")
+    assert url == "https://example.com/runner.tar.gz"
 
-    @responses.activate
-    def test_get_latest_release_error(self, github_instance):
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/actions/runner/releases/latest",
-            status=500,
-        )
-        with pytest.raises(
-            RuntimeError, match="Error getting latest release: *"
-        ):
-            github_instance._get_latest_release(repo="actions/runner")
 
-    @responses.activate
-    def test_get_latest_reunner_release_error(self, github_instance):
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/actions/runner/releases/latest",
-            status=200,
-            json={
-                "assets": [
-                    {
-                        "name": "actions-runner-linux-aarch64-2.0.0.tar.gz",
-                        "browser_download_url": "https://example.com/runner.tar.gz",
-                    }
-                ]
-            },
-        )
-        platform = "linux"
-        arch = "x64"
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/actions/runner/releases/latest",
-            status=500,
-        )
-        with pytest.raises(
-            RuntimeError,
-            match=f"Runner release not found for platform {platform} and architecture {arch}",
-        ):
-            github_instance.get_latest_runner_release("linux", "x64")
+def test_get_latest_runner_release_invalid_platform(github_instance):
+    with pytest.raises(ValueError):
+        github_instance.get_latest_runner_release("invalid", "x64")
+
+
+def test_get_latest_runner_release_invalid_arch(github_instance):
+    with pytest.raises(ValueError):
+        github_instance.get_latest_runner_release("linux", "invalid")
+
+
+@patch("time.sleep")  # Prevent actual sleeping in tests
+def test_wait_for_runner_success(mock_sleep, github_instance, mock_runner):
+    with patch.object(
+        github_instance, "get_runner", side_effect=[None, mock_runner]
+    ):
+        github_instance.wait_for_runner("test-label", timeout=30)
+        assert mock_sleep.call_count == 1
+
+
+@patch("time.sleep")
+@patch("time.time", side_effect=[0, 31])
+def test_wait_for_runner_timeout(mock_time, mock_sleep, github_instance):
+    with patch.object(github_instance, "get_runner", return_value=None):
+        with pytest.raises(RuntimeError):
+            github_instance.wait_for_runner("test-label", timeout=30)
+
+
+@responses.activate
+def test_get_latest_release(github_instance):
+    json = {
+        "url": "https://api.github.com/repos/octocat/Hello-World/releases/1",
+        "html_url": "https://github.com/octocat/Hello-World/releases/v1.0.0",
+        "assets_url": "https://api.github.com/repos/octocat/Hello-World/releases/1/assets",
+        "upload_url": "https://uploads.github.com/repos/octocat/Hello-World/releases/1/assets{?name,label}",
+        "tarball_url": "https://api.github.com/repos/octocat/Hello-World/tarball/v1.0.0",
+        "zipball_url": "https://api.github.com/repos/octocat/Hello-World/zipball/v1.0.0",
+        "discussion_url": "https://github.com/octocat/Hello-World/discussions/90",
+        "id": 1,
+        "assets": [
+            {
+                "url": "https://api.github.com/repos/octocat/Hello-World/releases/assets/1",
+                "browser_download_url": "https://github.com/octocat/Hello-World/releases/download/v1.0.0/example.zip",
+                "id": 1,
+                "node_id": "MDEyOlJlbGVhc2VBc3NldDE=",
+                "name": "example.zip",
+                "label": "short description",
+                "state": "uploaded",
+                "content_type": "application/zip",
+                "size": 1024,
+                "download_count": 42,
+                "created_at": "2013-02-27T19:35:32Z",
+                "updated_at": "2013-02-27T19:35:32Z",
+                "uploader": {
+                    "login": "octocat",
+                    "id": 1,
+                    "node_id": "MDQ6VXNlcjE=",
+                    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/octocat",
+                    "html_url": "https://github.com/octocat",
+                    "followers_url": "https://api.github.com/users/octocat/followers",
+                    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                    "organizations_url": "https://api.github.com/users/octocat/orgs",
+                    "repos_url": "https://api.github.com/users/octocat/repos",
+                    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/octocat/received_events",
+                    "type": "User",
+                    "site_admin": False,
+                },
+            }
+        ],
+    }
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/actions/runner/releases/latest",
+        status=200,
+        json=json,
+    )
+    body = github_instance._get_latest_release(repo="actions/runner")
+    assert body == json
+
+
+@responses.activate
+def test_get_latest_release_error(github_instance):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/actions/runner/releases/latest",
+        status=500,
+    )
+    with pytest.raises(RuntimeError, match="Error getting latest release: *"):
+        github_instance._get_latest_release(repo="actions/runner")
+
+
+@responses.activate
+def test_get_latest_reunner_release_error(github_instance):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/actions/runner/releases/latest",
+        status=200,
+        json={
+            "assets": [
+                {
+                    "name": "actions-runner-linux-aarch64-2.0.0.tar.gz",
+                    "browser_download_url": "https://example.com/runner.tar.gz",
+                }
+            ]
+        },
+    )
+    platform = "linux"
+    arch = "x64"
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/actions/runner/releases/latest",
+        status=500,
+    )
+    with pytest.raises(
+        RuntimeError,
+        match=f"Runner release not found for platform {platform} and architecture {arch}",
+    ):
+        github_instance.get_latest_runner_release("linux", "x64")


### PR DESCRIPTION
This pull request includes significant changes to the `gha_runner` module, focusing on refactoring the code to remove dependencies on the `PyGithub` library and improving error handling. The most important changes include the removal of `PyGithub`, the introduction of new data classes and custom exceptions, and the addition of new methods to handle GitHub API requests.

Refactoring and dependency removal:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L8-R15): Removed `PyGithub` from the dependencies list and added `responses`
* [`src/gha_runner/gh.py`](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bL3-R5): Removed imports of `Github` and `Auth` from the `PyGithub` library. [[1]](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bL3-R5) [[2]](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bL45-L46)

Error handling improvements:

* [`src/gha_runner/gh.py`](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bR20-R31): Added `RunnerListError` exception class to handle errors when retrieving the list of runners.
* [`src/gha_runner/gh.py`](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bR96-R99): Modified `_do_request` method to catch `JSONDecodeError` and return the raw response content if JSON decoding fails.

New data classes and methods:

* [`src/gha_runner/gh.py`](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bR20-R31): Introduced `SelfHostedRunner` data class to represent a self-hosted runner.
* [`src/gha_runner/gh.py`](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bR270-R286): Added `_get_latest_release` method to fetch the latest release information from a repository.
* [`src/gha_runner/gh.py`](diffhunk://#diff-0c52748c06c4725f3f8bd68c13402c4c057530573a05766d0e061a54918a1a5bL317-R328): Refactored `get_latest_runner_release` method to use the new `_get_latest_release` method and handle the response accordingly.

These changes aim to streamline the codebase, improve maintainability, and enhance error handling when interacting with the GitHub API.